### PR TITLE
解析表格内容时，表格顶部线无法显示

### DIFF
--- a/wxParse/wxParse.wxss
+++ b/wxParse/wxParse.wxss
@@ -181,6 +181,7 @@ view{
 	display: flex;
 	border-right:1px solid #e0e0e0;
 	border-bottom:1px solid #e0e0e0;
+	border-top:1px solid #e0e0e0;
 }
 .wxParse-th,
 .wxParse-td{


### PR DESCRIPTION
在进行表格的解析过程中，表格顶部的线没有显示。通过修改wxParse.wsxx内的wxParse-tr属性值进行修正